### PR TITLE
feat: add dot pagination to slideshow

### DIFF
--- a/src/app/components/slideshow/slideshow.component.css
+++ b/src/app/components/slideshow/slideshow.component.css
@@ -13,10 +13,10 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background-color: rgba(0, 0, 0, 0.5);
-  color: #fff;
+  background: transparent;
+  color: #333;
   border: none;
-  padding: 0.5rem;
+  font-size: 2rem;
   cursor: pointer;
 }
 
@@ -26,4 +26,25 @@
 
 .nav-button.right {
   right: 0.5rem;
+}
+
+.dot-container {
+  position: absolute;
+  bottom: 0.5rem;
+  width: 100%;
+  text-align: center;
+}
+
+.dot {
+  height: 10px;
+  width: 10px;
+  margin: 0 3px;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 50%;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.dot.active {
+  background-color: rgba(0, 0, 0, 0.8);
 }

--- a/src/app/components/slideshow/slideshow.component.html
+++ b/src/app/components/slideshow/slideshow.component.html
@@ -12,4 +12,13 @@
   <button type="button" class="nav-button right" (click)="next()">
     &#10095;
   </button>
+
+  <div class="dot-container">
+    <span
+      class="dot"
+      *ngFor="let image of images; let i = index"
+      [class.active]="i === currentIndex"
+      (click)="goToSlide(i)"
+    ></span>
+  </div>
 </div>

--- a/src/app/components/slideshow/slideshow.component.ts
+++ b/src/app/components/slideshow/slideshow.component.ts
@@ -44,4 +44,8 @@ export class SlideshowComponent implements OnInit, OnDestroy {
     this.currentIndex =
       (this.currentIndex - 1 + this.images.length) % this.images.length;
   }
+
+  public goToSlide(index: number): void {
+    this.currentIndex = index % this.images.length;
+  }
 }


### PR DESCRIPTION
## Summary
- simplify slideshow navigation buttons to a minimalist style
- add clickable dot pagination to slideshow

## Testing
- `npm test --silent` *(fails: No inputs were found in config file '/workspace/FastKart/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a3018427f88327a3a87c1551e831dd